### PR TITLE
Support side effects only import

### DIFF
--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -1,25 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`babel-plugin-react-native-platform-specific-extensions Should not do anything with a global import (to be implemented): Should not do anything with a global import (to be implemented) 1`] = `
-"
-import \\"./styles.scss\\"
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-import \\"./styles.scss\\";
-"
-`;
-
-exports[`babel-plugin-react-native-platform-specific-extensions Should not do anything with a global import (to be implemented): Should not do anything with a global import (to be implemented) 2`] = `
-"
-import \\"./something.txt\\"
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-import \\"./something.txt\\";
-"
-`;
-
 exports[`babel-plugin-react-native-platform-specific-extensions Should not react to file types that are not defined in plugin options (.scss): Should not react to file types that are not defined in plugin options (.scss) 1`] = `
 "
 import styles from \\"./styles.scss\\"
@@ -61,6 +41,17 @@ var myStyles = Platform.OS === \\"ios\\" ? require(\\"./myStylesFile.ios.scss\\"
 "
 `;
 
+exports[`babel-plugin-react-native-platform-specific-extensions Should require android and native files if they exits (side-effects-only import case): Should require android and native files if they exits (side-effects-only import case) 1`] = `
+"
+import styles from \\"./styles.scss\\"
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { Platform } from \\"react-native\\";
+var styles = Platform.OS === \\"android\\" ? require(\\"./styles.android.scss\\") : require(\\"./styles.native.scss\\");
+"
+`;
+
 exports[`babel-plugin-react-native-platform-specific-extensions Should require android and native files if they exits: Should require android and native files if they exits 1`] = `
 "
 import styles from \\"./styles.scss\\"
@@ -69,6 +60,17 @@ import styles from \\"./styles.scss\\"
 
 import { Platform } from \\"react-native\\";
 var styles = Platform.OS === \\"android\\" ? require(\\"./styles.android.scss\\") : require(\\"./styles.native.scss\\");
+"
+`;
+
+exports[`babel-plugin-react-native-platform-specific-extensions Should require android and non prefixed file (side-effects-only import case): Should require android and non prefixed file (side-effects-only import case) 1`] = `
+"
+import styles from \\"./styles.scss\\"
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { Platform } from \\"react-native\\";
+var styles = Platform.OS === \\"android\\" ? require(\\"./styles.android.scss\\") : require(\\"./styles.scss\\");
 "
 `;
 
@@ -83,6 +85,17 @@ var styles = Platform.OS === \\"android\\" ? require(\\"./styles.android.scss\\"
 "
 `;
 
+exports[`babel-plugin-react-native-platform-specific-extensions Should require ios and android files if they exits (side-effects-only import case): Should require ios and android files if they exits (side-effects-only import case) 1`] = `
+"
+import styles from \\"./styles.scss\\"
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { Platform } from \\"react-native\\";
+var styles = Platform.OS === \\"ios\\" ? require(\\"./styles.ios.scss\\") : require(\\"./styles.android.scss\\");
+"
+`;
+
 exports[`babel-plugin-react-native-platform-specific-extensions Should require ios and android files if they exits: Should require ios and android files if they exits 1`] = `
 "
 import styles from \\"./styles.scss\\"
@@ -91,6 +104,17 @@ import styles from \\"./styles.scss\\"
 
 import { Platform } from \\"react-native\\";
 var styles = Platform.OS === \\"ios\\" ? require(\\"./styles.ios.scss\\") : require(\\"./styles.android.scss\\");
+"
+`;
+
+exports[`babel-plugin-react-native-platform-specific-extensions Should require ios and native files if they exits (side-effects-only import case): Should require ios and native files if they exits (side-effects-only import case) 1`] = `
+"
+import styles from \\"./styles.scss\\"
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { Platform } from \\"react-native\\";
+var styles = Platform.OS === \\"ios\\" ? require(\\"./styles.ios.scss\\") : require(\\"./styles.native.scss\\");
 "
 `;
 
@@ -105,6 +129,17 @@ var styles = Platform.OS === \\"ios\\" ? require(\\"./styles.ios.scss\\") : requ
 "
 `;
 
+exports[`babel-plugin-react-native-platform-specific-extensions Should require ios and non prefixed file (side-effects-only import case): Should require ios and non prefixed file (side-effects-only import case) 1`] = `
+"
+import styles from \\"./styles.scss\\"
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { Platform } from \\"react-native\\";
+var styles = Platform.OS === \\"ios\\" ? require(\\"./styles.ios.scss\\") : require(\\"./styles.scss\\");
+"
+`;
+
 exports[`babel-plugin-react-native-platform-specific-extensions Should require ios and non prefixed file: Should require ios and non prefixed file 1`] = `
 "
 import styles from \\"./styles.scss\\"
@@ -113,6 +148,16 @@ import styles from \\"./styles.scss\\"
 
 import { Platform } from \\"react-native\\";
 var styles = Platform.OS === \\"ios\\" ? require(\\"./styles.ios.scss\\") : require(\\"./styles.scss\\");
+"
+`;
+
+exports[`babel-plugin-react-native-platform-specific-extensions Should require native file if it exists (side-effects-only import case): Should require native file if it exists (side-effects-only import case) 1`] = `
+"
+import styles from \\"./styles.scss\\"
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import styles from \\"./styles.native.scss\\";
 "
 `;
 
@@ -137,6 +182,17 @@ var styles = Platform.OS === \\"ios\\" ? require(\\"./styles.ios.scss\\") : requ
 "
 `;
 
+exports[`babel-plugin-react-native-platform-specific-extensions Should work with other extension types (.json) (side-effects-only import case): Should work with other extension types (.json) (side-effects-only import case) 1`] = `
+"
+import json from \\"./something.json\\"
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { Platform } from \\"react-native\\";
+var json = Platform.OS === \\"ios\\" ? require(\\"./something.ios.json\\") : require(\\"./something.android.json\\");
+"
+`;
+
 exports[`babel-plugin-react-native-platform-specific-extensions Should work with other extension types (.json): Should work with other extension types (.json) 1`] = `
 "
 import json from \\"./something.json\\"
@@ -145,6 +201,17 @@ import json from \\"./something.json\\"
 
 import { Platform } from \\"react-native\\";
 var json = Platform.OS === \\"ios\\" ? require(\\"./something.ios.json\\") : require(\\"./something.android.json\\");
+"
+`;
+
+exports[`babel-plugin-react-native-platform-specific-extensions Should work with other extension types (.txt) (side-effects-only import case): Should work with other extension types (.txt) (side-effects-only import case) 1`] = `
+"
+import txt from \\"./something.txt\\"
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { Platform } from \\"react-native\\";
+var txt = Platform.OS === \\"ios\\" ? require(\\"./something.ios.txt\\") : require(\\"./something.android.txt\\");
 "
 `;
 

--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -87,12 +87,12 @@ var styles = Platform.OS === \\"android\\" ? require(\\"./styles.android.scss\\"
 
 exports[`babel-plugin-react-native-platform-specific-extensions Should require ios and android files if they exits (side-effects-only import case): Should require ios and android files if they exits (side-effects-only import case) 1`] = `
 "
-import styles from \\"./styles.scss\\"
+import \\"./styles.scss\\"
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
 import { Platform } from \\"react-native\\";
-var styles = Platform.OS === \\"ios\\" ? require(\\"./styles.ios.scss\\") : require(\\"./styles.android.scss\\");
+Platform.OS === \\"ios\\" ? require(\\"./styles.ios.scss\\") : require(\\"./styles.android.scss\\");
 "
 `;
 

--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -171,6 +171,16 @@ import styles from \\"./styles.native.scss\\";
 "
 `;
 
+exports[`babel-plugin-react-native-platform-specific-extensions Should throw if no extensions defined in options: Should throw if no extensions defined in options 1`] = `
+"
+import styles from \\"./styles.scss\\"
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+Error: unknown: You have not specified any extensions in the plugin options.
+"
+`;
+
 exports[`babel-plugin-react-native-platform-specific-extensions Should transform import if path.dirname returns the same folder than fs.existsSync: Should transform import if path.dirname returns the same folder than fs.existsSync 1`] = `
 "
 import styles from \\"./styles.scss\\"

--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -43,12 +43,12 @@ var myStyles = Platform.OS === \\"ios\\" ? require(\\"./myStylesFile.ios.scss\\"
 
 exports[`babel-plugin-react-native-platform-specific-extensions Should require android and native files if they exits (side-effects-only import case): Should require android and native files if they exits (side-effects-only import case) 1`] = `
 "
-import styles from \\"./styles.scss\\"
+import \\"./styles.scss\\"
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
 import { Platform } from \\"react-native\\";
-var styles = Platform.OS === \\"android\\" ? require(\\"./styles.android.scss\\") : require(\\"./styles.native.scss\\");
+Platform.OS === \\"android\\" ? require(\\"./styles.android.scss\\") : require(\\"./styles.native.scss\\");
 "
 `;
 
@@ -65,12 +65,12 @@ var styles = Platform.OS === \\"android\\" ? require(\\"./styles.android.scss\\"
 
 exports[`babel-plugin-react-native-platform-specific-extensions Should require android and non prefixed file (side-effects-only import case): Should require android and non prefixed file (side-effects-only import case) 1`] = `
 "
-import styles from \\"./styles.scss\\"
+import \\"./styles.scss\\"
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
 import { Platform } from \\"react-native\\";
-var styles = Platform.OS === \\"android\\" ? require(\\"./styles.android.scss\\") : require(\\"./styles.scss\\");
+Platform.OS === \\"android\\" ? require(\\"./styles.android.scss\\") : require(\\"./styles.scss\\");
 "
 `;
 
@@ -109,12 +109,12 @@ var styles = Platform.OS === \\"ios\\" ? require(\\"./styles.ios.scss\\") : requ
 
 exports[`babel-plugin-react-native-platform-specific-extensions Should require ios and native files if they exits (side-effects-only import case): Should require ios and native files if they exits (side-effects-only import case) 1`] = `
 "
-import styles from \\"./styles.scss\\"
+import \\"./styles.scss\\"
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
 import { Platform } from \\"react-native\\";
-var styles = Platform.OS === \\"ios\\" ? require(\\"./styles.ios.scss\\") : require(\\"./styles.native.scss\\");
+Platform.OS === \\"ios\\" ? require(\\"./styles.ios.scss\\") : require(\\"./styles.native.scss\\");
 "
 `;
 
@@ -131,12 +131,12 @@ var styles = Platform.OS === \\"ios\\" ? require(\\"./styles.ios.scss\\") : requ
 
 exports[`babel-plugin-react-native-platform-specific-extensions Should require ios and non prefixed file (side-effects-only import case): Should require ios and non prefixed file (side-effects-only import case) 1`] = `
 "
-import styles from \\"./styles.scss\\"
+import \\"./styles.scss\\"
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
 import { Platform } from \\"react-native\\";
-var styles = Platform.OS === \\"ios\\" ? require(\\"./styles.ios.scss\\") : require(\\"./styles.scss\\");
+Platform.OS === \\"ios\\" ? require(\\"./styles.ios.scss\\") : require(\\"./styles.scss\\");
 "
 `;
 
@@ -153,11 +153,11 @@ var styles = Platform.OS === \\"ios\\" ? require(\\"./styles.ios.scss\\") : requ
 
 exports[`babel-plugin-react-native-platform-specific-extensions Should require native file if it exists (side-effects-only import case): Should require native file if it exists (side-effects-only import case) 1`] = `
 "
-import styles from \\"./styles.scss\\"
+import \\"./styles.scss\\"
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import styles from \\"./styles.native.scss\\";
+import \\"./styles.native.scss\\";
 "
 `;
 
@@ -184,12 +184,12 @@ var styles = Platform.OS === \\"ios\\" ? require(\\"./styles.ios.scss\\") : requ
 
 exports[`babel-plugin-react-native-platform-specific-extensions Should work with other extension types (.json) (side-effects-only import case): Should work with other extension types (.json) (side-effects-only import case) 1`] = `
 "
-import json from \\"./something.json\\"
+import \\"./something.json\\"
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
 import { Platform } from \\"react-native\\";
-var json = Platform.OS === \\"ios\\" ? require(\\"./something.ios.json\\") : require(\\"./something.android.json\\");
+Platform.OS === \\"ios\\" ? require(\\"./something.ios.json\\") : require(\\"./something.android.json\\");
 "
 `;
 
@@ -206,12 +206,12 @@ var json = Platform.OS === \\"ios\\" ? require(\\"./something.ios.json\\") : req
 
 exports[`babel-plugin-react-native-platform-specific-extensions Should work with other extension types (.txt) (side-effects-only import case): Should work with other extension types (.txt) (side-effects-only import case) 1`] = `
 "
-import txt from \\"./something.txt\\"
+import \\"./something.txt\\"
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
 import { Platform } from \\"react-native\\";
-var txt = Platform.OS === \\"ios\\" ? require(\\"./something.ios.txt\\") : require(\\"./something.android.txt\\");
+Platform.OS === \\"ios\\" ? require(\\"./something.ios.txt\\") : require(\\"./something.android.txt\\");
 "
 `;
 

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -168,13 +168,84 @@ pluginTester({
       }
     },
     {
-      title: "Should not do anything with a global import (to be implemented)",
-      code: `import "./styles.scss"`,
+      title:
+        "Should require ios and android files if they exits (side-effects-only import case)",
+      code: `import styles from "./styles.scss"`,
       setup() {
         spy = jest.spyOn(fs, "existsSync").mockImplementation(path => {
           return (
             /styles\.ios\.scss/.test(path) || /styles\.android\.scss/.test(path)
           );
+        });
+      },
+      teardown() {
+        spy.mockRestore();
+      }
+    },
+    {
+      title:
+        "Should require ios and native files if they exits (side-effects-only import case)",
+      code: `import styles from "./styles.scss"`,
+      setup() {
+        spy = jest.spyOn(fs, "existsSync").mockImplementation(path => {
+          return (
+            /styles\.ios\.scss/.test(path) || /styles\.native\.scss/.test(path)
+          );
+        });
+      },
+      teardown() {
+        spy.mockRestore();
+      }
+    },
+    {
+      title:
+        "Should require android and native files if they exits (side-effects-only import case)",
+      code: `import styles from "./styles.scss"`,
+      setup() {
+        spy = jest.spyOn(fs, "existsSync").mockImplementation(path => {
+          return (
+            /styles\.android\.scss/.test(path) ||
+            /styles\.native\.scss/.test(path)
+          );
+        });
+      },
+      teardown() {
+        spy.mockRestore();
+      }
+    },
+    {
+      title:
+        "Should require ios and non prefixed file (side-effects-only import case)",
+      code: `import styles from "./styles.scss"`,
+      setup() {
+        spy = jest.spyOn(fs, "existsSync").mockImplementation(path => {
+          return /styles\.ios\.scss/.test(path);
+        });
+      },
+      teardown() {
+        spy.mockRestore();
+      }
+    },
+    {
+      title:
+        "Should require android and non prefixed file (side-effects-only import case)",
+      code: `import styles from "./styles.scss"`,
+      setup() {
+        spy = jest.spyOn(fs, "existsSync").mockImplementation(path => {
+          return /styles\.android\.scss/.test(path);
+        });
+      },
+      teardown() {
+        spy.mockRestore();
+      }
+    },
+    {
+      title:
+        "Should require native file if it exists (side-effects-only import case)",
+      code: `import styles from "./styles.scss"`,
+      setup() {
+        spy = jest.spyOn(fs, "existsSync").mockImplementation(path => {
+          return /styles\.native\.scss/.test(path);
         });
       },
       teardown() {
@@ -238,13 +309,30 @@ pluginTester({
       }
     },
     {
-      title: "Should not do anything with a global import (to be implemented)",
-      code: `import "./something.txt"`,
+      title:
+        "Should work with other extension types (.txt) (side-effects-only import case)",
+      code: `import txt from "./something.txt"`,
       setup() {
         spy = jest.spyOn(fs, "existsSync").mockImplementation(path => {
           return (
             /something\.ios\.txt/.test(path) ||
             /something\.android\.txt/.test(path)
+          );
+        });
+      },
+      teardown() {
+        spy.mockRestore();
+      }
+    },
+    {
+      title:
+        "Should work with other extension types (.json) (side-effects-only import case)",
+      code: `import json from "./something.json"`,
+      setup() {
+        spy = jest.spyOn(fs, "existsSync").mockImplementation(path => {
+          return (
+            /something\.ios\.json/.test(path) ||
+            /something\.android\.json/.test(path)
           );
         });
       },

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -185,7 +185,7 @@ pluginTester({
     {
       title:
         "Should require ios and native files if they exits (side-effects-only import case)",
-      code: `import styles from "./styles.scss"`,
+      code: `import "./styles.scss"`,
       setup() {
         spy = jest.spyOn(fs, "existsSync").mockImplementation(path => {
           return (
@@ -200,7 +200,7 @@ pluginTester({
     {
       title:
         "Should require android and native files if they exits (side-effects-only import case)",
-      code: `import styles from "./styles.scss"`,
+      code: `import "./styles.scss"`,
       setup() {
         spy = jest.spyOn(fs, "existsSync").mockImplementation(path => {
           return (
@@ -216,7 +216,7 @@ pluginTester({
     {
       title:
         "Should require ios and non prefixed file (side-effects-only import case)",
-      code: `import styles from "./styles.scss"`,
+      code: `import "./styles.scss"`,
       setup() {
         spy = jest.spyOn(fs, "existsSync").mockImplementation(path => {
           return /styles\.ios\.scss/.test(path);
@@ -229,7 +229,7 @@ pluginTester({
     {
       title:
         "Should require android and non prefixed file (side-effects-only import case)",
-      code: `import styles from "./styles.scss"`,
+      code: `import "./styles.scss"`,
       setup() {
         spy = jest.spyOn(fs, "existsSync").mockImplementation(path => {
           return /styles\.android\.scss/.test(path);
@@ -242,7 +242,7 @@ pluginTester({
     {
       title:
         "Should require native file if it exists (side-effects-only import case)",
-      code: `import styles from "./styles.scss"`,
+      code: `import "./styles.scss"`,
       setup() {
         spy = jest.spyOn(fs, "existsSync").mockImplementation(path => {
           return /styles\.native\.scss/.test(path);
@@ -311,7 +311,7 @@ pluginTester({
     {
       title:
         "Should work with other extension types (.txt) (side-effects-only import case)",
-      code: `import txt from "./something.txt"`,
+      code: `import "./something.txt"`,
       setup() {
         spy = jest.spyOn(fs, "existsSync").mockImplementation(path => {
           return (
@@ -327,7 +327,7 @@ pluginTester({
     {
       title:
         "Should work with other extension types (.json) (side-effects-only import case)",
-      code: `import json from "./something.json"`,
+      code: `import "./something.json"`,
       setup() {
         spy = jest.spyOn(fs, "existsSync").mockImplementation(path => {
           return (

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -342,3 +342,19 @@ pluginTester({
     }
   ]
 });
+
+pluginTester({
+  plugin: platformSpecific,
+  pluginName: "babel-plugin-react-native-platform-specific-extensions",
+  pluginOptions: {},
+  snapshot: true,
+  tests: [
+    {
+      title: "Should throw if no extensions defined in options",
+      code: `import styles from "./styles.scss"`,
+      error: "You have not specified any extensions in the plugin options.",
+      setup() {},
+      teardown() {}
+    }
+  ]
+});

--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -170,7 +170,7 @@ pluginTester({
     {
       title:
         "Should require ios and android files if they exits (side-effects-only import case)",
-      code: `import styles from "./styles.scss"`,
+      code: `import "./styles.scss"`,
       setup() {
         spy = jest.spyOn(fs, "existsSync").mockImplementation(path => {
           return (


### PR DESCRIPTION
Fixes https://github.com/kristerkari/babel-plugin-react-native-platform-specific-extensions/issues/5

Adds support for the `import "./myfile.css";` style imports (side effects only imports) by:
1. Continuing processing even when there is no specifier, which happens when the import statement is side-effects-only (`import "module-name"`)
2. Omit assigning to a var in AST since it's a side-effects-only import anyway, but do the import/require so the side-effects can happen

While at it, this PR introduces a helper function (`astTernary()`) to easily produce the Babel AST fragment.

👋 @kristerkari , thanks for the Babel plugin! I recently ran into the issue at hand and thought I should try to contribute back by suggesting a solution. I didn't see a `CONTRIBUTING.md` file available so, please feel free to point out anything that's not of your liking.

Note, I'm not an experienced JS or Babel developer so this solution might have serious "gotchas" that I'm not aware of. Happy to try and revise if you have any issues to raise!

Let me know what you think, thanks!